### PR TITLE
fix(bm25): bump nltk to 3.9.1 & download punk_tab

### DIFF
--- a/milvus_model/sparse/bm25/tokenizers.py
+++ b/milvus_model/sparse/bm25/tokenizers.py
@@ -61,7 +61,7 @@ class StandardTokenizer:
         try:
            word_tokenize("this is a simple test.") 
         except LookupError:
-            nltk.download("punkt")
+            nltk.download("punkt_tab")
     def tokenize(self, text: str):
         return word_tokenize(text)
 

--- a/milvus_model/utils/__init__.py
+++ b/milvus_model/utils/__init__.py
@@ -36,7 +36,7 @@ def import_FlagEmbedding():
     _check_library("FlagEmbedding", package="FlagEmbedding>=1.2.2")
 
 def import_nltk():
-    _check_library("nltk", package="nltk")
+    _check_library("nltk", package="nltk>=3.9.1")
 
 def import_transformers():
     _check_library("transformers", package="transformers>=4.36.0")


### PR DESCRIPTION
This PR updates the NLTK dependency to version 3.9.1 and ensures the 'punkt_tab' tokenizer is downloaded. These changes address potential issues with text tokenization in the BM25 implementation.

This resolve this [issue](https://github.com/nltk/nltk/issues/3293) when using `StandardTokenizer` 
