### PR TITLE
fix(dependencies): fix breaking change in FlagEmbedding 1.3 dependency

### DIFF
--- a/milvus_model/utils/__init__.py
+++ b/milvus_model/utils/__init__.py
@@ -33,7 +33,7 @@ def import_sentence_transformers():
 
 def import_FlagEmbedding():
     _check_library("peft", package="peft")
-    _check_library("FlagEmbedding", package="FlagEmbedding>=1.2.2")
+    _check_library("FlagEmbedding", package="FlagEmbedding~=1.2.11")
 
 def import_nltk():
     _check_library("nltk", package="nltk>=3.9.1")


### PR DESCRIPTION
## Description

FlagEmbedding v1.3.X has breaking change with pymilvus/milvus-model : 

```
Error occurred: M3Embedder.encode() missing 1 required positional argument: 'queries'
```

This is a hotfix to force a version 1.2.X.

I think it's quite urgent since it can break multiple production system with lazy dependency loader.