### PR TITLE
fix model config "device" for BGEM3FlagModel

### DIFF
--- a/src/pymilvus/model/hybrid/bge_m3.py
+++ b/src/pymilvus/model/hybrid/bge_m3.py
@@ -58,7 +58,7 @@ class BGEM3EmbeddingFunction(BaseEmbeddingFunction):
         _model_config = dict(
             {
                 "model_name_or_path": model_name,
-                "devices": device,
+                "device": device,
                 "normalize_embeddings": normalize_embeddings,
                 "use_fp16": use_fp16,
             },


### PR DESCRIPTION
BGEM3EmbeddingFunction(device="cpu")
will get error: "BGEM3FlagModel.__init__() got an unexpected keyword argument 'devices'" since the model config has typo.