### PR TITLE
Revert "fix model config "device" for BGEM3FlagModel"

### DIFF
--- a/src/pymilvus/model/hybrid/bge_m3.py
+++ b/src/pymilvus/model/hybrid/bge_m3.py
@@ -58,7 +58,7 @@ class BGEM3EmbeddingFunction(BaseEmbeddingFunction):
         _model_config = dict(
             {
                 "model_name_or_path": model_name,
-                "device": device,
+                "devices": device,
                 "normalize_embeddings": normalize_embeddings,
                 "use_fp16": use_fp16,
             },


### PR DESCRIPTION
Reverts milvus-io/milvus-model#73

The latest BGEM3FlagModel receive `devices`: https://github.com/FlagOpen/FlagEmbedding/blob/master/FlagEmbedding/inference/embedder/encoder_only/m3.py