### PR TITLE
Fix bge_m3.py unexpected keyword argument 'devices'

### DIFF
--- a/src/pymilvus/model/hybrid/bge_m3.py
+++ b/src/pymilvus/model/hybrid/bge_m3.py
@@ -58,7 +58,7 @@ class BGEM3EmbeddingFunction(BaseEmbeddingFunction):
         _model_config = dict(
             {
                 "model_name_or_path": model_name,
-                "devices": device,
+                "device": device,
                 "normalize_embeddings": normalize_embeddings,
                 "use_fp16": use_fp16,
             },


### PR DESCRIPTION
TypeError: BGEM3FlagModel.__init__() got an unexpected keyword argument 'devices'